### PR TITLE
Broccoli soup: forgot to drain the can of chickpeas

### DIFF
--- a/soups/broccoli-soup.md
+++ b/soups/broccoli-soup.md
@@ -5,7 +5,7 @@
 - 2 cloves of garlic
 - one onion
 - 2 bouillon cubes
-- 1 can of chickpeas
+- 1 can of chickpeas, drained
 - 800 mL water
 - one big splash of oat cream
 - Olive oil


### PR DESCRIPTION
Small addition to broccoli soup recipe, so that you don't forget to drain the can of chickpeas!